### PR TITLE
remove CosmosClient request_timeout; use uv for venv installs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,15 +13,36 @@
 			"label": "pip install (functions)",
 			"type": "shell",
 			"osx": {
-				"command": "uv pip install -r requirements.txt"
+				"command": "uv pip install -r requirements.txt --python ${config:azureFunctions.pythonVenv}/bin/python"
 			},
 			"windows": {
-				"command": "${config:azureFunctions.pythonVenv}\\Scripts\\python -m pip install -r requirements.txt"
+				"command": "uv pip install -r requirements.txt --python ${config:azureFunctions.pythonVenv}\\Scripts\\python.exe"
 			},
 			"linux": {
-				"command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
+				"command": "uv pip install -r requirements.txt --python ${config:azureFunctions.pythonVenv}/bin/python"
 			},
 			"problemMatcher": []
+		},
+		{
+			"label": "start func host (venv)",
+			"type": "shell",
+			"command": "source .venv/bin/activate && func host start",
+			"isBackground": true,
+			"group": "build"
+		},
+		{
+			"label": "func: host start (shell)",
+			"type": "shell",
+			"command": "source .venv/bin/activate && func host start",
+			"isBackground": true,
+			"group": "build"
+		},
+		{
+			"label": "pip install (functions)",
+			"type": "shell",
+			"command": "uv pip install -r requirements.txt --python ${config:azureFunctions.pythonVenv}/bin/python",
+			"problemMatcher": [],
+			"group": "build"
 		}
 	]
 }

--- a/inventory_api/db.py
+++ b/inventory_api/db.py
@@ -45,7 +45,7 @@ try:
     logger.info("Initializing Cosmos DB client with DefaultAzureCredential")
     _credential = DefaultAzureCredential()
 
-    cosmos_client = CosmosClient(COSMOSDB_ENDPOINT, _credential, request_timeout=30)
+    cosmos_client = CosmosClient(COSMOSDB_ENDPOINT, _credential)
 
     logger.info(
         "Cosmos DB client initialized successfully",


### PR DESCRIPTION
Drop request_timeout from CosmosClient to avoid premature connect timeouts (azure-cosmos 4.9.0); rely on SDK defaults for stable behavior.
Switch tasks.json to uv pip across OS with --python pointing to .venv for faster, reproducible installs